### PR TITLE
fix: fall back to .next body when sw.js export is missing

### DIFF
--- a/scripts/copy-sw.mjs
+++ b/scripts/copy-sw.mjs
@@ -4,15 +4,48 @@
 // that header, so a worker at /serwist/sw.js would be capped to /serwist/ scope
 // and never control the app. Copying it to the site root makes its default
 // scope `/` with no header required, which is what static hosting needs.
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, readdirSync } from "node:fs";
 
-const src = "out/serwist/sw.js";
-const dest = "out/sw.js";
+// `next build` with `output: "export"` is meant to write the route handler
+// output to out/serwist/sw.js, but that export step is unreliable across
+// platforms: it lands on disk locally (Windows) yet is silently missing in CI
+// (Linux), with the same Next and Node versions. The compiled body is always
+// written to .next/server/app/serwist/<param>.body during the build, before and
+// independent of the export phase, and is byte-identical to the exported file.
+// Fall back to it so the root copy is produced in either environment.
+function firstExisting(candidates) {
+  return candidates.find((p) => existsSync(p));
+}
 
-if (!existsSync(src)) {
-  console.error(`[copy-sw] ${src} not found - did 'next build' run?`);
+const swSrc = firstExisting([
+  "out/serwist/sw.js",
+  ".next/server/app/serwist/sw.js.body",
+]);
+
+if (!swSrc) {
+  console.error("[copy-sw] service worker not found - did 'next build' run?");
+  for (const dir of ["out/serwist", ".next/server/app/serwist"]) {
+    if (existsSync(dir)) {
+      console.error(`[copy-sw]   ${dir}: ${readdirSync(dir).join(", ")}`);
+    }
+  }
   process.exit(1);
 }
 
-copyFileSync(src, dest);
-console.log(`[copy-sw] ${src} -> ${dest}`);
+copyFileSync(swSrc, "out/sw.js");
+console.log(`[copy-sw] ${swSrc} -> out/sw.js`);
+
+// The worker ends with sourceMappingURL=sw.js.map, which resolves to /sw.js.map
+// once served from the root, so copy the map alongside it to avoid a 404. A
+// missing map is not fatal - it only affects debugging.
+const mapSrc = firstExisting([
+  "out/serwist/sw.js.map",
+  ".next/server/app/serwist/sw.js.map.body",
+]);
+
+if (mapSrc) {
+  copyFileSync(mapSrc, "out/sw.js.map");
+  console.log(`[copy-sw] ${mapSrc} -> out/sw.js.map`);
+} else {
+  console.warn("[copy-sw] sw.js.map not found, skipping (non-fatal)");
+}


### PR DESCRIPTION
The Pages deploy failed in postbuild with "out/serwist/sw.js not found". next build with output: export is meant to write the serwist route handler output to out/serwist/sw.js, but that export step is unreliable across platforms: the file lands on disk locally (Windows) yet is silently absent in CI (Linux) on the same Next and Node versions, so copy-sw.mjs had nothing to copy to the site root.

Next always writes the compiled worker to
.next/server/app/serwist/sw.js.body during the build, independent of the export phase and byte-identical to the exported file. Fall back to it so the root copy is produced in either environment. Also emit sw.js.map alongside so the worker's sourceMappingURL no longer 404s at the root.