### PR TITLE
fix: stop configure-pages from injecting a config that breaks export

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -54,13 +54,15 @@ jobs:
           node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
+        # Deliberately no `static_site_generator: next`. That option makes
+        # configure-pages write a ./next.config.js, which it cannot do for our
+        # next.config.ts, so it drops a minimal JS config that Next 16 loads in
+        # preference to ours. That injected config lacks `output: "export"`, so
+        # the static site is never written to out/ and the build fails at the
+        # postbuild copy step. Our next.config.ts already sets output: "export"
+        # and images.unoptimized, and the site is served from a root custom
+        # domain, so no basePath injection is needed.
         uses: actions/configure-pages@v4
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # next.js
 /.next/
 /out/
+# Guard against a stray next.config.js: Next 16 loads it in preference to our
+# next.config.ts, silently dropping output: "export" (see .github/workflows/nextjs.yml).
+/next.config.js
 
 # onnxruntime-web wasm binaries (generated from node_modules by scripts/copy-ort-wasm.mjs)
 /public/wasm/

--- a/scripts/copy-sw.mjs
+++ b/scripts/copy-sw.mjs
@@ -4,48 +4,22 @@
 // that header, so a worker at /serwist/sw.js would be capped to /serwist/ scope
 // and never control the app. Copying it to the site root makes its default
 // scope `/` with no header required, which is what static hosting needs.
-import { copyFileSync, existsSync, readdirSync } from "node:fs";
+import { copyFileSync, existsSync } from "node:fs";
 
-// `next build` with `output: "export"` is meant to write the route handler
-// output to out/serwist/sw.js, but that export step is unreliable across
-// platforms: it lands on disk locally (Windows) yet is silently missing in CI
-// (Linux), with the same Next and Node versions. The compiled body is always
-// written to .next/server/app/serwist/<param>.body during the build, before and
-// independent of the export phase, and is byte-identical to the exported file.
-// Fall back to it so the root copy is produced in either environment.
-function firstExisting(candidates) {
-  return candidates.find((p) => existsSync(p));
-}
-
-const swSrc = firstExisting([
-  "out/serwist/sw.js",
-  ".next/server/app/serwist/sw.js.body",
-]);
-
-if (!swSrc) {
-  console.error("[copy-sw] service worker not found - did 'next build' run?");
-  for (const dir of ["out/serwist", ".next/server/app/serwist"]) {
-    if (existsSync(dir)) {
-      console.error(`[copy-sw]   ${dir}: ${readdirSync(dir).join(", ")}`);
-    }
-  }
+const src = "out/serwist/sw.js";
+if (!existsSync(src)) {
+  console.error(`[copy-sw] ${src} not found - did 'next build' export to out/?`);
   process.exit(1);
 }
 
-copyFileSync(swSrc, "out/sw.js");
-console.log(`[copy-sw] ${swSrc} -> out/sw.js`);
+copyFileSync(src, "out/sw.js");
+console.log(`[copy-sw] ${src} -> out/sw.js`);
 
 // The worker ends with sourceMappingURL=sw.js.map, which resolves to /sw.js.map
 // once served from the root, so copy the map alongside it to avoid a 404. A
 // missing map is not fatal - it only affects debugging.
-const mapSrc = firstExisting([
-  "out/serwist/sw.js.map",
-  ".next/server/app/serwist/sw.js.map.body",
-]);
-
-if (mapSrc) {
+const mapSrc = "out/serwist/sw.js.map";
+if (existsSync(mapSrc)) {
   copyFileSync(mapSrc, "out/sw.js.map");
   console.log(`[copy-sw] ${mapSrc} -> out/sw.js.map`);
-} else {
-  console.warn("[copy-sw] sw.js.map not found, skipping (non-fatal)");
 }


### PR DESCRIPTION
The Pages deploy failed at the postbuild copy-sw step because out/ was never created. Root cause: the Setup Pages step used static_site_generator: next, which makes actions/configure-pages write a ./next.config.js. It cannot edit our next.config.ts, so it drops a minimal JS config that Next 16 loads in preference to ours. That injected config has no output: "export", so next build prerenders to .next but never exports the static site to out/.

Reproduced locally by adding the same next.config.js: the build emits the identical "Unrecognized key(s) in object: 'images' at experimental" warning and produces no out/ directory, exactly as in CI. Removing it restores out/.

Our next.config.ts already sets output: "export" and images.unoptimized, and the site is served from a root custom domain, so configure-pages does not need to inject anything. Drop the static_site_generator input.

With out/ reliably exported again, revert copy-sw.mjs to copy straight from out/serwist/sw.js instead of reaching into .next internals, and keep copying sw.js.map so the worker's sourceMappingURL does not 404 at the root.