### PR TITLE
feat: WAV and MP3 audio export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chord-seq-ai-app",
       "version": "0.1.0",
       "dependencies": {
+        "@breezystack/lamejs": "^1.2.7",
         "@mdx-js/loader": "^3.0.1",
         "@mdx-js/react": "^3.0.1",
         "@next/mdx": "^16.2.9",
@@ -319,6 +320,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@breezystack/lamejs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz",
+      "integrity": "sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==",
+      "license": "LGPL-3.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -2156,18 +2163,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@serwist/turbopack/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@serwist/turbopack/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "^8.5.15"
   },
   "dependencies": {
+    "@breezystack/lamejs": "^1.2.7",
     "@mdx-js/loader": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
     "@next/mdx": "^16.2.9",

--- a/src/components/transpose_import_export/export_dropdown.tsx
+++ b/src/components/transpose_import_export/export_dropdown.tsx
@@ -3,9 +3,11 @@ import Select from "../ui/select";
 interface Props {
   dropdownRef: React.RefObject<HTMLDivElement | null>;
   setIsExportDropdownOpen: (state: boolean) => void;
-  handleExport: (format: string) => void;
+  handleExport: (format: string) => Promise<void>;
   format: string;
   setFormat: (format: string) => void;
+  formats: string[];
+  isRendering: boolean;
 }
 
 export default function ExportDropdown({
@@ -14,6 +16,8 @@ export default function ExportDropdown({
   setIsExportDropdownOpen,
   format,
   setFormat,
+  formats,
+  isRendering,
 }: Props) {
   return (
     <div
@@ -25,20 +29,21 @@ export default function ExportDropdown({
         selectName="format"
         state={format}
         setState={setFormat}
-        allStates={[".chseq", ".mid"]}
+        allStates={formats}
         width="15dvh"
         enabledShortcuts={true}
         onDark={true}
       />
       <button
-        className="rounded-[0.5dvw] bg-zinc-800 p-[0.5dvw] hover:bg-zinc-900"
+        className="rounded-[0.5dvw] bg-zinc-800 p-[0.5dvw] hover:bg-zinc-900 disabled:cursor-not-allowed disabled:opacity-60"
         title="Export (Enter)"
+        disabled={isRendering}
         onClick={() => {
-          handleExport(format);
-          setIsExportDropdownOpen(false);
+          // Keep the dropdown open while audio renders, then close it.
+          handleExport(format).then(() => setIsExportDropdownOpen(false));
         }}
       >
-        Export
+        {isRendering ? "Rendering..." : "Export"}
       </button>
     </div>
   );

--- a/src/components/transpose_import_export/transpose_import_export.tsx
+++ b/src/components/transpose_import_export/transpose_import_export.tsx
@@ -7,9 +7,13 @@ import Image from "next/image";
 
 import { transpositionMap } from "@/data/transposition_map";
 import { getMidiBlob, extractMidiFile } from "@/playback/midi_io";
+import { getWavBlob, getMp3Blob } from "@/playback/audio_render";
 
 import TransposeDropdown from "./transpose_dropdown";
 import ExportDropdown from "./export_dropdown";
+
+// Available export formats, also used to cycle the selection with the arrow keys.
+const exportFormats = [".chseq", ".mid", ".wav", ".mp3"];
 
 export default function TransposeImportExport() {
   const [
@@ -187,8 +191,14 @@ export default function TransposeImportExport() {
 
   /* Export */
   const [format, setFormat] = useState(".chseq");
+  const [isRendering, setIsRendering] = useState(false);
 
   const formatRef = useRef(format);
+  const isRenderingRef = useRef(isRendering);
+
+  useEffect(() => {
+    isRenderingRef.current = isRendering;
+  }, [isRendering]);
 
   useEffect(() => {
     formatRef.current = format;
@@ -208,7 +218,11 @@ export default function TransposeImportExport() {
 
   // Export given the format
   const handleExport = useCallback(
-    (format: string) => {
+    async (format: string) => {
+      // Audio rendering is async and can take a moment; ignore re-entry while
+      // a render is already in flight.
+      if (isRenderingRef.current) return;
+
       incrementTimesExported();
       if (format === ".chseq") {
         const jsonData = JSON.stringify({
@@ -223,6 +237,23 @@ export default function TransposeImportExport() {
         const blob = getMidiBlob(chords, bpm, signature);
 
         downloadFile(blob, "chords.mid");
+      }
+      if (format === ".wav" || format === ".mp3") {
+        setIsRendering(true);
+        try {
+          const blob =
+            format === ".wav"
+              ? await getWavBlob(chords, bpm)
+              : await getMp3Blob(chords, bpm);
+
+          downloadFile(blob, `chords${format}`);
+        } catch (error) {
+          alert(
+            "Couldn't render the audio. Make sure the sequence isn't empty and you're online (instrument samples are loaded from the web).",
+          );
+        } finally {
+          setIsRendering(false);
+        }
       }
     },
     [bpm, chords, incrementTimesExported, signature],
@@ -274,14 +305,23 @@ export default function TransposeImportExport() {
       transposeChords(parseInt(input.value, 10));
       setShowTransposeDropdown(false);
     }
-    // Confirm the export
+    // Confirm the export (keep the dropdown open while audio renders, then close)
     if (showExportDropdownRef.current) {
-      handleExport(formatRef.current);
-      setShowExportDropdown(false);
+      handleExport(formatRef.current).then(() => setShowExportDropdown(false));
     }
   }, [transposeChords, handleExport]);
 
   const keyEventHandlers: Record<string, () => void> = useMemo(() => {
+    // Step through the export formats, wrapping around at either end.
+    const cycleFormat = (direction: 1 | -1) => {
+      const i = exportFormats.indexOf(formatRef.current);
+      setFormat(
+        exportFormats[
+          (i + direction + exportFormats.length) % exportFormats.length
+        ],
+      );
+    };
+
     return {
       KeyT: () => {
         setShowTransposeDropdown(!showTransposeDropdownRef.current);
@@ -299,10 +339,8 @@ export default function TransposeImportExport() {
           if (!input) return;
           input.value = Math.min(parseInt(input.value, 10) + 1, 11).toString();
         }
-        // Change the export format
-        if (showExportDropdownRef.current) {
-          setFormat(formatRef.current === ".chseq" ? ".mid" : ".chseq");
-        }
+        // Cycle to the previous export format
+        if (showExportDropdownRef.current) cycleFormat(-1);
       },
       ArrowDown: () => {
         // Decrement the value in the transpose dropdown
@@ -311,10 +349,8 @@ export default function TransposeImportExport() {
           if (!input) return;
           input.value = Math.max(parseInt(input.value, 10) - 1, -11).toString();
         }
-        // Change the export format
-        if (showExportDropdownRef.current) {
-          setFormat(formatRef.current === ".chseq" ? ".mid" : ".chseq");
-        }
+        // Cycle to the next export format
+        if (showExportDropdownRef.current) cycleFormat(1);
       },
       Enter: () => handleEnterKey(),
       NumpadEnter: () => handleEnterKey(),
@@ -414,6 +450,8 @@ export default function TransposeImportExport() {
           handleExport={handleExport}
           format={format}
           setFormat={setFormat}
+          formats={exportFormats}
+          isRendering={isRendering}
         />
       )}
     </section>

--- a/src/playback/audio_render.tsx
+++ b/src/playback/audio_render.tsx
@@ -1,0 +1,159 @@
+import * as Tone from "tone";
+import { Mp3Encoder } from "@breezystack/lamejs";
+
+import { chordsToNoteEvents } from "./player";
+import { samplerConfig, reverbDecay } from "./instrument_config";
+
+// The offline render rebuilds the same sampler+reverb graph as live playback
+// (shared via instrument_config) so exported audio matches what the user hears,
+// and pads the render by the reverb + sampler-release tail so it is not clipped.
+const RENDER_TAIL = reverbDecay + samplerConfig.release; // seconds
+const SAMPLE_RATE = 44100;
+const CHANNELS = 2;
+const MP3_KBPS = 192;
+
+type Chord = { index: number; token: number; duration: number; variant: number };
+
+// Render a chord sequence to an AudioBuffer entirely offline (no real-time
+// playback). The sampler and reverb must be constructed inside the offline
+// context - the live instances in player.tsx belong to a different context and
+// cannot be reused here.
+async function renderSequence(chords: Chord[], bpm: number): Promise<AudioBuffer> {
+  const { events, totalTime } = chordsToNoteEvents(chords, bpm);
+
+  if (totalTime <= 0 || events.length === 0) {
+    throw new Error("Nothing to render - the sequence is empty.");
+  }
+
+  const buffer = await Tone.Offline(
+    async (context) => {
+      const synth = new Tone.Sampler(samplerConfig).toDestination();
+
+      const reverb = new Tone.Reverb(reverbDecay).toDestination();
+      synth.connect(reverb);
+
+      // Offline rendering does not wait for async setup on its own: the
+      // Salamander samples download over the network and the reverb generates
+      // its impulse response asynchronously, so both must be awaited before the
+      // transport runs or the render comes out silent.
+      await Tone.loaded();
+      await reverb.generate();
+
+      const part = new Tone.Part((time, value) => {
+        synth.triggerAttackRelease(value.note, value.duration, time);
+      }, events);
+      part.start(0);
+
+      context.transport.start();
+    },
+    totalTime + RENDER_TAIL,
+    CHANNELS,
+    SAMPLE_RATE,
+  );
+
+  const audioBuffer = buffer.get();
+  if (!audioBuffer) {
+    throw new Error("Offline render produced no audio.");
+  }
+  return audioBuffer;
+}
+
+// Clamp a float sample to [-1, 1] and scale it to a signed 16-bit integer.
+function floatToInt16(input: Float32Array): Int16Array {
+  const output = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return output;
+}
+
+// Encode an AudioBuffer as a 16-bit PCM WAV file. Lossless and dependency-free,
+// at the cost of file size - the best format for importing into a DAW.
+function audioBufferToWav(buffer: AudioBuffer): Blob {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const numSamples = buffer.length;
+  const bytesPerSample = 2;
+  const blockAlign = numChannels * bytesPerSample;
+  const dataSize = numSamples * blockAlign;
+
+  const arrayBuffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(arrayBuffer);
+
+  const writeString = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) {
+      view.setUint8(offset + i, str.charCodeAt(i));
+    }
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM chunk size
+  view.setUint16(20, 1, true); // audio format: PCM
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true); // bits per sample
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  // Convert each channel to 16-bit once, then interleave into the data chunk.
+  const channels: Int16Array[] = [];
+  for (let ch = 0; ch < numChannels; ch++) {
+    channels.push(floatToInt16(buffer.getChannelData(ch)));
+  }
+
+  let offset = 44;
+  for (let i = 0; i < numSamples; i++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      view.setInt16(offset, channels[ch][i], true);
+      offset += 2;
+    }
+  }
+
+  return new Blob([view], { type: "audio/wav" });
+}
+
+// Encode an AudioBuffer as MP3 via lamejs (pure-JS, runs in the browser since
+// the app is a static export with no server). Smaller and easier to share than
+// WAV, which is what the feature request asked for.
+function audioBufferToMp3(buffer: AudioBuffer): Blob {
+  const numChannels = Math.min(buffer.numberOfChannels, 2);
+  const encoder = new Mp3Encoder(numChannels, buffer.sampleRate, MP3_KBPS);
+
+  const left = floatToInt16(buffer.getChannelData(0));
+  const right =
+    numChannels > 1 ? floatToInt16(buffer.getChannelData(1)) : undefined;
+
+  const blockSize = 1152; // lamejs encodes in 1152-sample frames
+  const chunks: Uint8Array[] = [];
+
+  for (let i = 0; i < left.length; i += blockSize) {
+    const leftChunk = left.subarray(i, i + blockSize);
+    const mp3buf = right
+      ? encoder.encodeBuffer(leftChunk, right.subarray(i, i + blockSize))
+      : encoder.encodeBuffer(leftChunk);
+    if (mp3buf.length > 0) chunks.push(new Uint8Array(mp3buf));
+  }
+
+  const flushed = encoder.flush();
+  if (flushed.length > 0) chunks.push(new Uint8Array(flushed));
+
+  return new Blob(chunks as BlobPart[], { type: "audio/mpeg" });
+}
+
+// Render the sequence and return a WAV blob ready for download.
+export async function getWavBlob(chords: Chord[], bpm: number): Promise<Blob> {
+  const buffer = await renderSequence(chords, bpm);
+  return audioBufferToWav(buffer);
+}
+
+// Render the sequence and return an MP3 blob ready for download.
+export async function getMp3Blob(chords: Chord[], bpm: number): Promise<Blob> {
+  const buffer = await renderSequence(chords, bpm);
+  return audioBufferToMp3(buffer);
+}

--- a/src/playback/instrument_config.tsx
+++ b/src/playback/instrument_config.tsx
@@ -1,0 +1,16 @@
+// Shared piano instrument settings so live playback (player.tsx) and offline
+// audio export (audio_render.tsx) always sound identical. Tweaking the samples
+// or the reverb here updates both paths at once, avoiding silent divergence
+// between what the user hears and what they download.
+export const samplerConfig = {
+  urls: {
+    C4: "C4.mp3",
+    "D#4": "Ds4.mp3",
+    "F#4": "Fs4.mp3",
+    A4: "A4.mp3",
+  },
+  release: 1, // seconds
+  baseUrl: "https://tonejs.github.io/audio/salamander/",
+};
+
+export const reverbDecay = 3; // seconds

--- a/src/playback/player.tsx
+++ b/src/playback/player.tsx
@@ -1,6 +1,7 @@
 import * as Tone from "tone";
 import { chordToNotes } from "@/data/chord_to_notes";
 import { tokenToChord } from "@/data/token_to_chord";
+import { samplerConfig, reverbDecay } from "./instrument_config";
 
 let synth: Tone.Sampler;
 let metronomeSynth: Tone.Sampler;
@@ -17,18 +18,9 @@ Tone.loaded().then(() => {
   if (typeof window === "undefined") return;
   if (Tone.getDestination().volume) Tone.getDestination().volume.value = -8;
 
-  synth = new Tone.Sampler({
-    urls: {
-      C4: "C4.mp3",
-      "D#4": "Ds4.mp3",
-      "F#4": "Fs4.mp3",
-      A4: "A4.mp3",
-    },
-    release: 1,
-    baseUrl: "https://tonejs.github.io/audio/salamander/",
-  }).toDestination();
+  synth = new Tone.Sampler(samplerConfig).toDestination();
 
-  const reverb = new Tone.Reverb(3).toDestination();
+  const reverb = new Tone.Reverb(reverbDecay).toDestination();
   synth.connect(reverb);
 
   metronomeSynth = new Tone.Sampler({
@@ -51,6 +43,41 @@ function MIDIToFreq(midi: number) {
 
 function MIDIsToFreq(midi: number[]) {
   return midi.map((note) => MIDIToFreq(note));
+}
+
+// Flatten a chord sequence into timed note events (frequencies) and report the
+// total length in seconds. Shared by live playback (playSequence) and offline
+// audio rendering (audio_render.tsx) so both stay perfectly in sync.
+export function chordsToNoteEvents(
+  chords: { index: number; token: number; duration: number; variant: number }[],
+  bpm: number,
+): {
+  events: { time: number; note: number; duration: number }[];
+  totalTime: number;
+} {
+  const events: { time: number; note: number; duration: number }[] = [];
+  let totalTime = 0;
+
+  for (const chord of chords) {
+    const duration = chord.duration / (bpm / 60); // Duration in seconds
+
+    if (chord.token === -1) {
+      totalTime += duration;
+      continue;
+    }
+
+    const freqs = MIDIsToFreq(
+      chordToNotes[tokenToChord[chord.token][chord.variant]],
+    );
+
+    for (const freq of freqs) {
+      events.push({ time: totalTime, note: freq, duration: duration });
+    }
+
+    totalTime += duration;
+  }
+
+  return { events, totalTime };
 }
 
 export function playNotes(notes: number[]) {
@@ -97,30 +124,8 @@ export function playSequence(
   muteMetronome: boolean,
 ) {
   // Prepare the sequence
-  timeNoteDuration = [];
-  let totalTime = 0;
-  for (const chord of chords) {
-    const duration = chord.duration / (bpm / 60); // Duration in seconds
-
-    if (chord.token === -1) {
-      totalTime += duration;
-      continue;
-    }
-
-    const freqs = MIDIsToFreq(
-      chordToNotes[tokenToChord[chord.token][chord.variant]],
-    );
-
-    for (const freq of freqs) {
-      timeNoteDuration.push({
-        time: totalTime,
-        note: freq,
-        duration: duration,
-      });
-    }
-
-    totalTime += duration;
-  }
+  const { events, totalTime } = chordsToNoteEvents(chords, bpm);
+  timeNoteDuration = events;
 
   // Play the sequence
   Tone.loaded().then(() => {


### PR DESCRIPTION
Resolves #76.

Adds audio export so a chord progression can be downloaded as WAV or MP3, not just MIDI - requested by a music teacher to feed progressions into DAWs and AI music tools.

## What's in it
- `src/playback/audio_render.tsx` - renders the sequence with `Tone.Offline` (sampler + reverb rebuilt inside the offline context, padded for the reverb tail), then encodes to 16-bit PCM WAV (hand-rolled, zero-dep) or MP3 via
  `@breezystack/lamejs`.
- Refactor: shared `instrument_config` and an extracted `chordsToNoteEvents` so the offline render stays identical to live playback.
- Export dropdown gains `.wav` / `.mp3` with a "Rendering..." state.

## Notes
- Encoding is fully client-side (the app is a static export); this PR adds no new network dependency.
- Exported audio uses the same Salamander piano samples as playback. The app already loads them at startup and the service worker runtime-caches them, so warm sessions export fine offline. The offline render re-instantiates the sampler, so it relies on that cache rather than playback's in-memory buffers.
- Vendoring the samples into public/ + precaching would make the whole app (playback and export) work on a cold offline start - a separate, app-wide improvement, not export-specific.