### PR TITLE
chore: sync package-lock with npm 10 for CI deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2165,6 +2165,18 @@
         }
       }
     },
+    "node_modules/@serwist/turbopack/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@serwist/turbopack/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",


### PR DESCRIPTION
Adding the lamejs dependency was done locally under npm 11, which pruned the nested @swc/helpers@0.5.23 entry that CI's npm 10 still requires. That broke `npm ci` on the Pages deploy (Missing: @swc/helpers@0.5.23 from lock file). Regenerate the lockfile with npm 10 so it stays in sync with what CI installs.