### PR TITLE
chore: pin CI npm to 11 to match local lockfile generation

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Pin npm to match local lockfile generation
+        # node 22 ships npm 10, but our lockfile is generated with npm 11, which npm 10's `npm ci` rejects.
+        run: npm install -g npm@11
       - name: Setup Pages
         # Deliberately no `static_site_generator: next`. That option makes
         # configure-pages write a ./next.config.js, which it cannot do for our

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chord-seq-ai-app",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@11.11.0",
   "scripts": {
     "predev": "node ./scripts/copy-ort-wasm.mjs",
     "dev": "next dev",


### PR DESCRIPTION
The Pages deploy was failing on `npm ci` because the lockfile is generated locally with npm 11, while node 22 on CI ships npm 10, whose nested-dependency pruning differs and rejects the lockfile (Missing: @swc/helpers from lock file). This recurred on every dependency change.

Fix it at the source: declare the npm version via the packageManager field and install npm 11 in CI so both sides use the same major. This replaces the one-off lockfile re-pinning that only treated the symptom.