### PR TITLE
fix: prevent stale inference hangs

### DIFF
--- a/src/components/suggestions/suggestions.tsx
+++ b/src/components/suggestions/suggestions.tsx
@@ -298,20 +298,18 @@ const MemoizedSuggestions = React.memo(function MemoizedSuggestions({
   }
 
   /* Predict the next chord */
-  // Calls the prediction, split into a separate useEffect to allow the UI to update before the prediction
+  // Predict whenever the model input changes. Effect cleanup prevents a result
+  // from an older request from overwriting suggestions for newer input.
   useEffect(() => {
-    if (selectedChord === -1) return;
+    if (selectedChord === -1) {
+      setChordProbsLoading(false);
+      setErrorOccured(false);
+      return;
+    }
+
+    let active = true;
     setChordProbsLoading(true);
     setErrorOccured(false);
-  }, [chords, selectedChord, modelPath, selectedGenres, selectedDecades]);
-
-  // Actually predict the next chord when the prediction is requested (by chordProbsLoading)
-  const prevChordProbsLoading = useRef(chordProbsLoading);
-  useEffect(() => {
-    // Only predict if the prediction is requested
-    if (prevChordProbsLoading.current === chordProbsLoading) return;
-    prevChordProbsLoading.current = chordProbsLoading;
-    if (!chordProbsLoading) return;
 
     // Get the style if the model is conditional
     const style = normalizeStyle(selectedGenres).concat(
@@ -322,10 +320,12 @@ const MemoizedSuggestions = React.memo(function MemoizedSuggestions({
     // Predict the next chord
     predict(chords.slice(0, selectedChord), modelPath, inputStyle)
       .then((result) => {
+        if (!active) return;
         setChordProbs(result as { token: number; prob: number }[]);
         setChordProbsLoading(false);
       })
       .catch((error) => {
+        if (!active) return;
         switch (error.message) {
           case "model not loaded":
             alert(
@@ -336,28 +336,25 @@ const MemoizedSuggestions = React.memo(function MemoizedSuggestions({
             alert("Maximum number of chords reached. Please start a new song.");
             break;
           default:
-            if ("no available backend found" in error) {
+            if (error.message.includes("no available backend found")) {
               alert(
                 "No backend found. Please reload the page, your progress is saved. If the problem persists, try using a different browser.",
               );
+            } else {
+              alert(
+                `An error has occurred, try reloading the page. Your progress is saved.\n${error.message}`,
+              );
             }
-
-            alert(
-              `An error has occurred, try reloading the page. Your progress is saved.\n${error.message}`,
-            );
             break;
         }
         setChordProbsLoading(false);
         setErrorOccured(true);
       });
-  }, [
-    chordProbsLoading,
-    chords,
-    modelPath,
-    selectedChord,
-    selectedDecades,
-    selectedGenres,
-  ]);
+
+    return () => {
+      active = false;
+    };
+  }, [chords, modelPath, selectedChord, selectedDecades, selectedGenres]);
 
   /* Keyboard shortcuts */
   const enabledShortcutsRef = useRef(enabledShortcuts);

--- a/src/models/models.test.ts
+++ b/src/models/models.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const workers: FakeWorker[] = [];
+const storeMock = vi.hoisted(() => ({
+  setIsDownloadingModel: vi.fn(),
+  setPercentageDownloaded: vi.fn(),
+  setModelSize: vi.fn(),
+  setIsLoadingSession: vi.fn(),
+}));
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor() {
+    workers.push(this);
+  }
+}
+
+vi.mock("onnxruntime-web/webgpu", () => ({}));
+vi.mock("@/data/token_to_chord", () => ({
+  tokenToChord: {
+    0: ["C4"],
+    1: ["D4"],
+  },
+}));
+vi.mock("@/data/transposition_map", () => ({
+  transpositionMap: {
+    0: [0],
+    1: [1],
+  },
+}));
+vi.mock("@/state/use_store", () => ({
+  useStore: {
+    getState: () => storeMock,
+  },
+}));
+
+describe("predict", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("Worker", FakeWorker);
+    workers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects the matching prediction when the worker reports an async error", async () => {
+    const { predict } = await import("./models");
+    const prediction = predict([], "/models/recurrent_net.onnx");
+    const request = workers[0].postMessage.mock.calls[0][0];
+
+    expect(request).toMatchObject({
+      action: "predict",
+      requestId: 1,
+      modelPath: "/models/recurrent_net.onnx",
+    });
+
+    workers[0].onmessage?.({
+      data: {
+        requestId: request.requestId,
+        status: "error",
+        message: "WebGPU device was lost.",
+      },
+    } as MessageEvent);
+
+    await expect(prediction).rejects.toThrow("WebGPU device was lost.");
+    expect(workers[0].terminate).toHaveBeenCalledOnce();
+  });
+
+  it("cancels active work out-of-band when a newer prediction starts", async () => {
+    const { predict } = await import("./models");
+    const first = predict([], "/models/recurrent_net.onnx");
+    const second = predict(
+      [{ index: 0, token: 0, duration: 1, variant: 0 }],
+      "/models/transformer_small.onnx",
+    );
+    const firstRequest = workers[0].postMessage.mock.calls[0][0];
+    const secondRequest = workers[1].postMessage.mock.calls[0][0];
+
+    expect(workers[0].terminate).toHaveBeenCalledOnce();
+    expect(firstRequest.requestId).not.toBe(secondRequest.requestId);
+    await expect(first).rejects.toThrow("Prediction superseded.");
+
+    workers[1].onmessage?.({
+      data: {
+        requestId: secondRequest.requestId,
+        output: {
+          dims: [1, 2, 4],
+          cpuData: new Float32Array([0, 0, 0, 0, 0, 1, 0, 0]),
+        },
+      },
+    } as MessageEvent);
+
+    const secondResult = await second;
+    expect(secondResult[0]).toMatchObject({ token: 1 });
+  });
+
+  it("invalidates active progress before returning a cached prediction", async () => {
+    const { predict } = await import("./models");
+    const cachedInput = predict([], "/models/recurrent_net.onnx");
+    const cachedRequest = workers[0].postMessage.mock.calls[0][0];
+
+    workers[0].onmessage?.({
+      data: {
+        requestId: cachedRequest.requestId,
+        output: {
+          dims: [1, 1, 4],
+          cpuData: new Float32Array([1, 0, 0, 0]),
+        },
+      },
+    } as MessageEvent);
+    const cachedResult = await cachedInput;
+
+    const obsolete = predict(
+      [{ index: 0, token: 0, duration: 1, variant: 0 }],
+      "/models/transformer_small.onnx",
+    );
+    const obsoleteRequest = workers[0].postMessage.mock.calls[1][0];
+    const fromCache = await predict([], "/models/recurrent_net.onnx");
+
+    await expect(obsolete).rejects.toThrow("Prediction superseded.");
+    expect(fromCache).toEqual(cachedResult);
+
+    storeMock.setIsLoadingSession.mockClear();
+    workers[0].onmessage?.({
+      data: {
+        requestId: obsoleteRequest.requestId,
+        status: "setIsLoadingSession",
+        value: true,
+      },
+    } as MessageEvent);
+
+    expect(storeMock.setIsLoadingSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/models/models.tsx
+++ b/src/models/models.tsx
@@ -12,8 +12,106 @@ const maxCacheSize = 32;
 
 // Initialize the worker (predictions are made there to avoid blocking the main thread while using WebGPU)
 // Check https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#envwasmproxy for more info
-const worker = new Worker(new URL("../models/onnx_worker.ts", import.meta.url));
-let prevModelPath = "";
+const workerUrl = new URL("../models/onnx_worker.ts", import.meta.url);
+
+type Chord = {
+  index: number;
+  token: number;
+  duration: number;
+  variant: number;
+};
+
+type Prediction = { token: number; prob: number };
+
+type ActivePrediction = {
+  requestId: number;
+  chords: Chord[];
+  numChords: number;
+  cacheKey: string;
+  resolve: (predictions: Prediction[]) => void;
+  reject: (error: Error) => void;
+};
+
+let nextRequestId = 1;
+let activePrediction: ActivePrediction | null = null;
+
+function createWorker() {
+  const newWorker = new Worker(workerUrl);
+  newWorker.onmessage = handleWorkerMessage;
+  newWorker.onerror = (error) => handleWorkerError(newWorker, error);
+  return newWorker;
+}
+
+let worker = createWorker();
+
+function resetLoadingState() {
+  const state = useStore.getState();
+  state.setIsDownloadingModel(false);
+  state.setPercentageDownloaded(0);
+  state.setModelSize(0);
+  state.setIsLoadingSession(false);
+}
+
+function restartWorker() {
+  worker.terminate();
+  worker = createWorker();
+}
+
+function cancelActivePrediction() {
+  if (!activePrediction) return;
+
+  const canceled = activePrediction;
+  activePrediction = null;
+  restartWorker();
+  resetLoadingState();
+  canceled.reject(new Error("Prediction superseded."));
+}
+
+function handleWorkerMessage(event: MessageEvent) {
+  const { requestId, status, value, message, output } = event.data;
+  const active = activePrediction;
+  if (!active || requestId !== active.requestId) return;
+
+  if (status === "setDownloadingModel") {
+    useStore.getState().setIsDownloadingModel(value);
+  } else if (status === "setPercentageDownloaded") {
+    useStore.getState().setPercentageDownloaded(value);
+  } else if (status === "setModelSize") {
+    useStore.getState().setModelSize(value);
+  } else if (status === "setIsLoadingSession") {
+    useStore.getState().setIsLoadingSession(value);
+  }
+
+  if (status === "error") {
+    activePrediction = null;
+    resetLoadingState();
+    restartWorker();
+    active.reject(new Error(message || "Inference worker failed."));
+    return;
+  }
+
+  if (!output) return;
+
+  activePrediction = null;
+  try {
+    const predictions = processOutput(output as ort.Tensor, active);
+    resetLoadingState();
+    active.resolve(predictions);
+  } catch (error) {
+    resetLoadingState();
+    active.reject(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+function handleWorkerError(failedWorker: Worker, error: ErrorEvent) {
+  if (failedWorker !== worker) return;
+
+  const active = activePrediction;
+  activePrediction = null;
+  resetLoadingState();
+  restartWorker();
+  active?.reject(new Error(error.message || "Inference worker crashed."));
+}
 
 // Process the chords into a tensor that can be fed into the model
 function process_chords(
@@ -66,13 +164,40 @@ function softmax(arr: Float32Array) {
   return exps.map((x) => x / sumExps);
 }
 
+function processOutput(
+  output: ort.Tensor,
+  pending: ActivePrediction,
+): Prediction[] {
+  const column = getColumnSlice(output, pending.numChords - 1);
+
+  // Zero out the start and end tokens, as well as the previous chord
+  column[numTokens - 1] = -Infinity;
+  column[numTokens - 2] = -Infinity;
+  column[pending.chords[pending.chords.length - 1].token] = -Infinity;
+
+  const probs = softmax(column);
+  let chordProbs: Prediction[] = [];
+  for (let i = 0; i < probs.length - 2; i++) {
+    chordProbs.push({ token: i, prob: probs[i] });
+  }
+
+  if (pending.numChords === 1) {
+    chordProbs = processFirstPreds(chordProbs);
+  } else {
+    chordProbs.sort((a, b) => b.prob - a.prob);
+  }
+
+  predictionCache.set(pending.cacheKey, chordProbs);
+  if (predictionCache.size > maxCacheSize) {
+    const firstKey = predictionCache.keys().next().value;
+    if (firstKey) predictionCache.delete(firstKey);
+  }
+
+  return chordProbs;
+}
+
 export async function predict(
-  chords: {
-    index: number;
-    token: number;
-    duration: number;
-    variant: number;
-  }[],
+  chords: Chord[],
   modelPath: string,
   style?: number[],
 ) {
@@ -91,87 +216,39 @@ export async function predict(
   if (style) {
     strData += style.join(" ");
   }
-  if (predictionCache.has(strData)) {
-    return predictionCache.get(strData);
-  }
 
-  const resultPromise = new Promise<{ token: number; prob: number }[]>(
-    (resolve, reject) => {
-      worker.onmessage = (event) => {
-        // Handle set calls from the worker (cannot transfer the store directly)
-        if (event.data.status === "setDownloadingModel") {
-          useStore.getState().setIsDownloadingModel(event.data.value);
-        } else if (event.data.status === "setPercentageDownloaded") {
-          useStore.getState().setPercentageDownloaded(event.data.value);
-        } else if (event.data.status === "setModelSize") {
-          useStore.getState().setModelSize(event.data.value);
-        } else if (event.data.status === "setIsLoadingSession") {
-          useStore.getState().setIsLoadingSession(event.data.value);
-        }
+  // Only the newest UI request matters. Cancel in-flight work before checking
+  // the cache so stale worker progress cannot overwrite a cached result.
+  cancelActivePrediction();
 
-        // Handle the output
-        if (event.data.status === "modelLoaded") {
-          // Predict after the model is loaded
-          worker.postMessage({ action: "predict", data: data, style });
-        } else if (event.data.output) {
-          const { output } = event.data;
-          /* Process the output */
-          const column = getColumnSlice(
-            output as ort.Tensor,
-            (numChords as number) - 1,
-          ); // Only a single column is needed
+  const cached = predictionCache.get(strData);
+  if (cached) return cached;
 
-          // Zero out the start and end tokens, as well as the previous chord
-          column[numTokens - 1] = -Infinity;
-          column[numTokens - 2] = -Infinity;
-          column[chords[chords.length - 1].token] = -Infinity;
+  const requestId = nextRequestId++;
 
-          // Get the softmax probabilities
-          const probs = softmax(column);
+  return new Promise<Prediction[]>((resolve, reject) => {
+    activePrediction = {
+      requestId,
+      chords,
+      numChords: numChords as number,
+      cacheKey: strData,
+      resolve,
+      reject,
+    };
 
-          // Convert it to the wanted format, skip the start and end tokens
-          let chordProbs = [];
-          for (let i = 0; i < probs.length - 2; i++) {
-            chordProbs.push({ token: i, prob: probs[i] });
-          }
-
-          // Process or sort the predictions
-          if (numChords === 1) {
-            chordProbs = processFirstPreds(chordProbs);
-          } else {
-            chordProbs.sort((a, b) => b.prob - a.prob);
-          }
-
-          // Cache the result
-          predictionCache.set(strData, chordProbs);
-
-          // Clear the first element of the cache if it's too big
-          if (predictionCache.size > maxCacheSize) {
-            const firstKey = predictionCache.keys().next().value;
-            if (firstKey) {
-              predictionCache.delete(firstKey);
-            }
-          }
-
-          resolve(chordProbs);
-        }
-      };
-
-      worker.onerror = (error) => {
-        reject(error);
-      };
-    },
-  );
-
-  // Load the model or predict
-  if (!prevModelPath || prevModelPath !== modelPath) {
-    prevModelPath = modelPath;
-    worker.postMessage({ action: "loadModel", modelPath });
-  } else {
-    worker.postMessage({ action: "predict", data: data, style });
-  }
-
-  return resultPromise;
+    try {
+      worker.postMessage({
+        action: "predict",
+        requestId,
+        modelPath,
+        data,
+        style,
+      });
+    } catch (error) {
+      activePrediction = null;
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
 }
 
 // Tokens that are transpositions of one another should have the same probability, so we average them and sort

--- a/src/models/onnx_worker.test.ts
+++ b/src/models/onnx_worker.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ortMock = vi.hoisted(() => ({
+  createSession: vi.fn(),
+}));
+
+vi.mock("onnxruntime-web/webgpu", () => ({
+  env: {
+    wasm: {},
+    webgpu: { device: Promise.resolve(undefined) },
+  },
+  InferenceSession: { create: ortMock.createSession },
+  Tensor: class Tensor {
+    constructor(
+      public type: string,
+      public data: unknown,
+      public dims: number[],
+    ) {}
+  },
+}));
+
+type FakeWorkerScope = {
+  location: { origin: string };
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+};
+
+function predictionRequest(requestId = 7) {
+  return {
+    action: "predict",
+    requestId,
+    modelPath: "/models/recurrent_net.onnx",
+    data: new BigInt64Array(256),
+  };
+}
+
+describe("onnx worker", () => {
+  let workerScope: FakeWorkerScope;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ortMock.createSession.mockReset();
+    workerScope = {
+      location: { origin: "https://chordseqai.test" },
+      postMessage: vi.fn(),
+      onmessage: null,
+    };
+    vi.stubGlobal("self", workerScope);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3, 4]), {
+          status: 200,
+          headers: { "content-length": "4" },
+        }),
+      ),
+    );
+
+    await import("./onnx_worker");
+  });
+
+  it("retries an explicit WebGPU failure with WASM and preserves the request ID", async () => {
+    const webGpuRun = vi.fn().mockRejectedValue(new Error("GPU device lost"));
+    const wasmOutput = { output: { dims: [1, 1, 4] } };
+    const wasmRun = vi.fn().mockResolvedValue(wasmOutput);
+    ortMock.createSession
+      .mockResolvedValueOnce({ run: webGpuRun })
+      .mockResolvedValueOnce({ run: wasmRun });
+
+    workerScope.onmessage?.({ data: predictionRequest() } as MessageEvent);
+
+    await vi.waitFor(() => {
+      expect(workerScope.postMessage).toHaveBeenCalledWith({
+        requestId: 7,
+        output: wasmOutput.output,
+      });
+    });
+    expect(ortMock.createSession).toHaveBeenNthCalledWith(
+      1,
+      expect.any(ArrayBuffer),
+      { executionProviders: ["webgpu"] },
+    );
+    expect(ortMock.createSession).toHaveBeenNthCalledWith(
+      2,
+      expect.any(ArrayBuffer),
+      { executionProviders: ["wasm"] },
+    );
+  });
+
+  it("reports a correlated error when the explicit WASM fallback also fails", async () => {
+    ortMock.createSession
+      .mockResolvedValueOnce({
+        run: vi.fn().mockRejectedValue(new Error("GPU device lost")),
+      })
+      .mockResolvedValueOnce({
+        run: vi.fn().mockRejectedValue(new Error("WASM execution failed")),
+      });
+
+    workerScope.onmessage?.({ data: predictionRequest(11) } as MessageEvent);
+
+    await vi.waitFor(() => {
+      expect(workerScope.postMessage).toHaveBeenCalledWith({
+        requestId: 11,
+        status: "error",
+        message: expect.stringContaining("WASM execution failed"),
+      });
+    });
+  });
+});

--- a/src/models/onnx_worker.ts
+++ b/src/models/onnx_worker.ts
@@ -9,92 +9,184 @@ ort.env.wasm.wasmPaths = "/wasm/";
 // single-threaded wasm is the fallback.
 ort.env.wasm.numThreads = 1;
 
-// A global variable to store the model (avoids loading it every time we want to make a prediction)
+type PredictionRequest = {
+  action: "predict";
+  requestId: number;
+  modelPath: string;
+  data: BigInt64Array;
+  style?: number[];
+};
+
 let currentSession: ort.InferenceSession | null = null;
+let currentModelPath = "";
+let currentModelBuffer: ArrayBuffer | null = null;
+let usingWasm = false;
 
-self.onmessage = async (event) => {
-  const { modelPath, data, style, action } = event.data;
+function postStatus(requestId: number, status: string, value: unknown) {
+  self.postMessage({ requestId, status, value });
+}
 
-  if (action === "loadModel") {
-    self.postMessage({ status: "setDownloadingModel", value: true });
-    self.postMessage({ status: "setPercentageDownloaded", value: 0 });
+async function loadModel(requestId: number, modelPath: string) {
+  if (currentModelPath === modelPath && currentModelBuffer) return;
 
-    // Check if the model path is a valid URL
-    let modelName = "";
-    try {
-      let url = new URL(modelPath, self.location.origin);
-      modelName = /^\/models\/([^/]+)\.onnx$/.exec(url.pathname)?.[1] || "";
-    } catch {
-      self.reportError("Invalid model path.");
-      return;
-    }
-    const response = await fetch(`${self.location.origin}/models/${modelName}.onnx`);
+  postStatus(requestId, "setDownloadingModel", true);
+  postStatus(requestId, "setPercentageDownloaded", 0);
+  postStatus(requestId, "setModelSize", 0);
 
+  try {
+    const url = new URL(modelPath, self.location.origin);
+    const modelName = /^\/models\/([^/]+)\.onnx$/.exec(url.pathname)?.[1] || "";
+    if (!modelName) throw new Error("Invalid model path.");
+
+    const response = await fetch(
+      `${self.location.origin}/models/${modelName}.onnx`,
+    );
     if (!response.ok) {
-      self.reportError(`Failed to fetch model: ${response.statusText}.`);
-      return;
+      throw new Error(`Failed to fetch model: ${response.statusText}.`);
     }
 
     const contentLength = response.headers.get("content-length");
-    if (!contentLength) {
-      self.reportError("Failed to get content length from response headers.");
-      return;
-    }
-
-    const total = parseInt(contentLength, 10);
+    const total = contentLength ? parseInt(contentLength, 10) : 0;
     let loaded = 0;
-    // Set size in MB
-    self.postMessage({ status: "setModelSize", value: total / 1024 / 1024 });
-
-    // Track download progress
-    const reader = response?.body?.getReader();
-    let chunks = [];
-
-    if (!reader) {
-      self.reportError("Failed to get response body reader.");
-      return;
-    }
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      loaded += value.byteLength;
-      self.postMessage({
-        status: "setPercentageDownloaded",
-        value: loaded / total,
-      });
-      chunks.push(value);
+    if (total > 0) {
+      postStatus(requestId, "setModelSize", total / 1024 / 1024);
     }
 
-    const blob = new Blob(chunks);
-    const buffer = await blob.arrayBuffer();
-    self.postMessage({ status: "setDownloadingModel", value: false });
-
-    self.postMessage({ status: "setIsLoadingSession", value: true });
-    currentSession = await ort.InferenceSession.create(buffer, {
-      executionProviders: ["webgpu", "wasm"],
-    });
-    self.postMessage({ status: "setIsLoadingSession", value: false });
-
-    self.postMessage({ status: "modelLoaded" });
-  } else if (action === "predict" && currentSession) {
-    // Inference based on the model
-    let outputs = null;
-    if (style) {
-      outputs = await currentSession.run({
-        "input.1": new ort.Tensor("int64", data, [1, 256]),
-        "onnx::Gemm_1": new ort.Tensor(
-          "float32",
-          new Float32Array(style),
-          [1, 28],
-        ),
-      });
+    // Cached responses may omit Content-Length or expose no body reader. They
+    // are still valid and should not be treated as model failures.
+    const reader = response.body?.getReader();
+    let buffer: ArrayBuffer;
+    if (reader) {
+      const chunks: ArrayBuffer[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        loaded += value.byteLength;
+        postStatus(
+          requestId,
+          "setPercentageDownloaded",
+          total > 0 ? loaded / total : 0,
+        );
+        const chunk = new Uint8Array(value.byteLength);
+        chunk.set(value);
+        chunks.push(chunk.buffer);
+      }
+      buffer = await new Blob(chunks).arrayBuffer();
     } else {
-      outputs = await currentSession.run({
-        "input.1": new ort.Tensor("int64", data, [1, 256]),
-      });
+      buffer = await response.arrayBuffer();
     }
-    const outputTensor = Object.values(outputs)[0];
 
-    self.postMessage({ output: outputTensor });
+    currentModelPath = modelPath;
+    currentModelBuffer = buffer;
+    currentSession = null;
+    usingWasm = false;
+  } finally {
+    postStatus(requestId, "setDownloadingModel", false);
+  }
+}
+
+async function createSession(requestId: number, forceWasm: boolean) {
+  if (!currentModelBuffer) throw new Error("Model not loaded.");
+
+  postStatus(requestId, "setIsLoadingSession", true);
+  try {
+    currentSession = await ort.InferenceSession.create(currentModelBuffer, {
+      // Select one provider at a time so a successful session identifies the
+      // active backend unambiguously. Fallback is handled explicitly below.
+      executionProviders: forceWasm ? ["wasm"] : ["webgpu"],
+    });
+    usingWasm = forceWasm;
+  } finally {
+    postStatus(requestId, "setIsLoadingSession", false);
+  }
+}
+
+function createFeeds(
+  data: BigInt64Array,
+  style?: number[],
+): Record<string, ort.Tensor> {
+  const feeds: Record<string, ort.Tensor> = {
+    "input.1": new ort.Tensor("int64", data, [1, 256]),
+  };
+  if (style) {
+    feeds["onnx::Gemm_1"] = new ort.Tensor(
+      "float32",
+      new Float32Array(style),
+      [1, 28],
+    );
+  }
+  return feeds;
+}
+
+async function runCurrentSession(data: BigInt64Array, style?: number[]) {
+  if (!currentSession) throw new Error("Model not loaded.");
+
+  const device = usingWasm ? undefined : await ort.env.webgpu.device;
+  const run = currentSession.run(createFeeds(data, style));
+  if (!device) return run;
+
+  const deviceLost = device.lost.then((info) => {
+    const details = info.message || info.reason || "unknown reason";
+    throw new Error(`WebGPU device lost: ${details}`);
+  });
+  return Promise.race([run, deviceLost]);
+}
+
+async function handlePrediction(request: PredictionRequest) {
+  await loadModel(request.requestId, request.modelPath);
+
+  if (!currentSession) {
+    try {
+      await createSession(request.requestId, false);
+    } catch {
+      // Session creation explicitly failed with the preferred providers.
+      await createSession(request.requestId, true);
+    }
+  }
+
+  let outputs: ort.InferenceSession.OnnxValueMapType;
+  try {
+    outputs = await runCurrentSession(request.data, request.style);
+  } catch (webGpuError) {
+    if (usingWasm) throw webGpuError;
+
+    // Retry only after an explicit WebGPU inference failure or device-loss
+    // signal. Slow inference alone is never classified as failure.
+    await createSession(request.requestId, true);
+    try {
+      outputs = await runCurrentSession(request.data, request.style);
+    } catch (wasmError) {
+      const webGpuMessage =
+        webGpuError instanceof Error
+          ? webGpuError.message
+          : String(webGpuError);
+      const wasmMessage =
+        wasmError instanceof Error ? wasmError.message : String(wasmError);
+      throw new Error(
+        `WebGPU inference failed (${webGpuMessage}); WebAssembly fallback failed (${wasmMessage}).`,
+      );
+    }
+  }
+
+  const output = Object.values(outputs)[0];
+  self.postMessage({ requestId: request.requestId, output });
+}
+
+function reportError(requestId: number, error: unknown) {
+  postStatus(requestId, "setDownloadingModel", false);
+  postStatus(requestId, "setIsLoadingSession", false);
+  self.postMessage({
+    requestId,
+    status: "error",
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
+self.onmessage = async (event: MessageEvent<PredictionRequest>) => {
+  const request = event.data;
+  try {
+    await handlePrediction(request);
+  } catch (error) {
+    reportError(request.requestId, error);
   }
 };


### PR DESCRIPTION
Opera GX users could get stuck at Predicting suggestions... because worker failures and stale worker responses were not tied to the prediction request that started them. Clearing site cache happened to reset the worker/model state, but the app itself could leave the UI waiting on an obsolete prediction.

## What's in it
- **Prediction ownership** - keep one active prediction at a time, assign request IDs, ignore stale worker messages, and reset loading state when active work is cancelled or the worker fails.
- **Worker errors** - return correlated worker errors instead of leaving the caller pending, and restart the worker after explicit failures so the next prediction starts cleanly.
- **Backend fallback** - try WebGPU first and fall back to WASM only after an explicit WebGPU session/run/device-loss failure; slow inference alone is not treated as failure.
- **Model loading** - tolerate cached responses without Content-Length or a streaming body reader.
- **Suggestions UI** - collapse the split loading/prediction effects into one input-driven effect and prevent stale async results from updating current suggestions.
- **Tests** - cover stale request cancellation, cache-hit invalidation, correlated worker errors, and WebGPU-to-WASM fallback paths.

All green locally: prettier on touched files, 	sc, eslint, Vitest (35/35).