### PR TITLE
fix: preserve inference worker bootstrap config

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -49,6 +49,35 @@ test("app shell renders the editor toolbar", async ({ page }) => {
   await expect(page.getByTitle("Export (E)")).toBeVisible();
 });
 
+test("inference worker starts after the service worker takes control", async ({
+  page,
+}) => {
+  test.skip(
+    !process.env.CI,
+    "The service worker is enabled only in the production export.",
+  );
+
+  const bootstrapErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.text().includes("Missing worker bootstrap config")) {
+      bootstrapErrors.push(message.text());
+    }
+  });
+
+  await page.goto("/app");
+  await page.evaluate(() => navigator.serviceWorker.ready);
+  await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+
+  const workerStarted = page.waitForEvent("worker", (worker) =>
+    worker.url().includes("turbopack-worker"),
+  );
+  await page.reload();
+  await workerStarted;
+  await page.waitForTimeout(500);
+
+  expect(bootstrapErrors).toEqual([]);
+});
+
 test("exporting a .chseq file triggers a download", async ({ page }) => {
   await page.goto("/app");
 

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -32,4 +32,15 @@ const serwist = new Serwist({
   },
 });
 
+// Turbopack passes dedicated-worker bootstrap data in the worker URL fragment.
+// Fetch requests never include fragments, so responding to a worker request from
+// the service worker (including with a cached or network response) makes
+// Chromium start the worker without that data. Let the browser fetch worker
+// entrypoints directly so their location retains the original #params value.
+self.addEventListener("fetch", (event) => {
+  if (event.request.destination === "worker") {
+    event.stopImmediatePropagation();
+  }
+});
+
 serwist.addEventListeners();

--- a/src/models/models.test.ts
+++ b/src/models/models.test.ts
@@ -73,6 +73,29 @@ describe("predict", () => {
     expect(workers[0].terminate).toHaveBeenCalledOnce();
   });
 
+  it("recreates a crashed worker lazily instead of entering a restart loop", async () => {
+    const { predict } = await import("./models");
+
+    workers[0].onerror?.({
+      message: "Missing worker bootstrap config",
+    } as ErrorEvent);
+
+    expect(workers).toHaveLength(1);
+    expect(workers[0].terminate).toHaveBeenCalledOnce();
+
+    const retry = predict([], "/models/recurrent_net.onnx");
+
+    expect(workers).toHaveLength(2);
+    expect(workers[1].postMessage).toHaveBeenCalledOnce();
+
+    workers[1].onerror?.({
+      message: "Missing worker bootstrap config",
+    } as ErrorEvent);
+
+    await expect(retry).rejects.toThrow("Missing worker bootstrap config");
+    expect(workers).toHaveLength(2);
+  });
+
   it("cancels active work out-of-band when a newer prediction starts", async () => {
     const { predict } = await import("./models");
     const first = predict([], "/models/recurrent_net.onnx");

--- a/src/models/models.tsx
+++ b/src/models/models.tsx
@@ -43,6 +43,7 @@ function createWorker() {
 }
 
 let worker = createWorker();
+let workerFailed = false;
 
 function resetLoadingState() {
   const state = useStore.getState();
@@ -55,6 +56,14 @@ function resetLoadingState() {
 function restartWorker() {
   worker.terminate();
   worker = createWorker();
+  workerFailed = false;
+}
+
+function ensureWorker() {
+  if (!workerFailed) return;
+
+  worker = createWorker();
+  workerFailed = false;
 }
 
 function cancelActivePrediction() {
@@ -109,7 +118,8 @@ function handleWorkerError(failedWorker: Worker, error: ErrorEvent) {
   const active = activePrediction;
   activePrediction = null;
   resetLoadingState();
-  restartWorker();
+  failedWorker.terminate();
+  workerFailed = true;
   active?.reject(new Error(error.message || "Inference worker crashed."));
 }
 
@@ -227,6 +237,7 @@ export async function predict(
   const requestId = nextRequestId++;
 
   return new Promise<Prediction[]>((resolve, reject) => {
+    ensureWorker();
     activePrediction = {
       requestId,
       chords,


### PR DESCRIPTION
Chromium users could hit `Missing worker bootstrap config` on every AI action after the offline service worker took control. Turbopack puts dedicated-worker startup parameters in the URL fragment, but a Serwist-intercepted worker response loses that fragment, so the inference worker starts without its chunk configuration. A persistent startup failure also triggered an unbounded worker restart loop.

## What's in it
- **Service worker bypass** - let dedicated-worker entrypoints load directly in the browser so Turbopack's `#params` bootstrap data survives.
- **Crash recovery** - mark failed inference workers for lazy recreation instead of restarting immediately and looping on persistent startup failures.
- **Regression coverage** - verify lazy recovery in Vitest and exercise the production service-worker-controlled reload path in Chromium.

All green locally: Prettier on touched files, `tsc`, `eslint`, Vitest (36/36), Playwright (4/4), and `npm run build`.